### PR TITLE
Add indexselect benchmarks

### DIFF
--- a/benchmarks/cpp/nvfuser/CMakeLists.txt
+++ b/benchmarks/cpp/nvfuser/CMakeLists.txt
@@ -23,6 +23,7 @@ if(USE_CUDA)
     transpose.cpp
     matmul.cpp
     timm.cpp
+    indexselect.cpp
     utils.cpp
     main.cpp)
 

--- a/benchmarks/cpp/nvfuser/indexselect.cpp
+++ b/benchmarks/cpp/nvfuser/indexselect.cpp
@@ -1,0 +1,212 @@
+
+// Based on NVFuserTest.FusionBiasGeluBwd_CUDA
+
+#include <torch/csrc/jit/codegen/cuda/arith.h>
+#include <torch/csrc/jit/codegen/cuda/executor.h>
+#include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_builder.h>
+#include <torch/csrc/jit/codegen/cuda/lower2device.h>
+#include <torch/csrc/jit/codegen/cuda/scheduler/all_schedulers.h>
+
+#include <benchmark/benchmark.h>
+
+#include <cuda_runtime.h>
+
+#include <benchmarks/cpp/nvfuser/utils.h>
+
+using namespace torch::jit::fuser::cuda;
+
+static void setupFusion(Fusion* fusion) {
+  FusionGuard fg(fusion);
+
+  // set up input tensor views
+  auto t0 = makeContigTensor(2); // nDim = 2
+  fusion->addInput(t0);
+  // scaling tensor
+  auto t1 = makeContigTensor(2);
+  fusion->addInput(t1);
+  auto t_idx = makeContigTensor(1, DataType::Int);
+  fusion->addInput(t_idx);
+
+  auto t2 = index_select(t0, 0, t_idx); // select at dim=0
+  auto t3 = mul(t1, t2);
+  auto t4 = add(t3, IrBuilder::create<Double>(17.0));
+
+  // Save float output for validation
+  fusion->addOutput(t4);
+}
+
+static std::vector<c10::IValue> setupInputs() {
+  at::manual_seed(0);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  int nElem = 1023;
+  int nElem_select = nElem + 115;
+  int nFeat = 128;
+  std::vector<int64_t> input_shape{nElem, nFeat};
+  std::vector<int64_t> select_shape{nElem_select, nFeat};
+  auto at_input = at::randn(input_shape, options);
+  auto at_select = at::randn(select_shape, options);
+  auto indx_options = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+  auto at_index = at::randint(nElem, {nElem_select}, indx_options);
+  return {at_select, at_input, at_index};
+}
+
+//------------------------------------------------------------------------------
+
+static void IndexSelect_SetupFusion(benchmark::State& benchmark_state) {
+  for (auto _ : benchmark_state) {
+    Fusion fusion;
+    setupFusion(&fusion);
+  }
+}
+
+BENCHMARK(IndexSelect_SetupFusion)->Unit(benchmark::kMicrosecond);
+
+//------------------------------------------------------------------------------
+
+static void IndexSelect_AutoSchedule(benchmark::State& benchmark_state) {
+  for (auto _ : benchmark_state) {
+    // Setup (not included in the measurement)
+    benchmark_state.PauseTiming();
+    Fusion fusion;
+    setupFusion(&fusion);
+    std::vector<c10::IValue> inputs = setupInputs();
+    benchmark_state.ResumeTiming();
+
+    // Auto-schedule
+    schedulePointwise(&fusion, c10::ArrayRef<c10::IValue>(inputs));
+  }
+}
+
+BENCHMARK(IndexSelect_AutoSchedule)->Unit(benchmark::kMicrosecond);
+
+//------------------------------------------------------------------------------
+
+static void IndexSelect_Lower(benchmark::State& benchmark_state) {
+  Fusion fusion;
+
+  // setup fusion
+  setupFusion(&fusion);
+
+  // inputs
+  std::vector<c10::IValue> inputs = setupInputs();
+
+  schedulePointwise(&fusion, c10::ArrayRef<c10::IValue>(inputs));
+
+  for (auto _ : benchmark_state) {
+    GpuLower gpu_lower(&fusion);
+  }
+}
+
+BENCHMARK(IndexSelect_Lower)->Unit(benchmark::kMillisecond);
+
+//------------------------------------------------------------------------------
+
+static void IndexSelect_Compile(benchmark::State& benchmark_state) {
+  Fusion fusion;
+
+  // setup fusion
+  setupFusion(&fusion);
+
+  // inputs
+  std::vector<c10::IValue> inputs = setupInputs();
+
+  auto lparams = schedulePointwise(&fusion, c10::ArrayRef<c10::IValue>(inputs));
+
+  for (auto _ : benchmark_state) {
+    FusionExecutor executor;
+    executor.compileFusion(&fusion, c10::ArrayRef<c10::IValue>(inputs), lparams);
+  }
+}
+
+BENCHMARK(IndexSelect_Compile)->Unit(benchmark::kMillisecond);
+
+//------------------------------------------------------------------------------
+
+static void IndexSelect_RunFusion(benchmark::State& benchmark_state) {
+  Fusion fusion;
+
+  // setup fusion
+  setupFusion(&fusion);
+
+  // inputs
+  std::vector<c10::IValue> inputs = setupInputs();
+
+  auto lparams = schedulePointwise(&fusion, c10::ArrayRef<c10::IValue>(inputs));
+
+  FusionExecutor executor;
+  executor.compileFusion(&fusion, c10::ArrayRef<c10::IValue>(inputs), lparams);
+
+  C10_CUDA_CHECK(cudaDeviceSynchronize());
+
+  at::Tensor output = at::empty_like(inputs[0].toTensor());
+
+  for (auto _ : benchmark_state) {
+    executor.runFusion(c10::ArrayRef<c10::IValue>(inputs), {output}, lparams);
+    C10_CUDA_CHECK(cudaDeviceSynchronize());
+    clearL2Cache();
+  }
+}
+
+BENCHMARK(IndexSelect_RunFusion)->Unit(benchmark::kMicrosecond);
+
+//------------------------------------------------------------------------------
+
+// static void IndexSelect_RunFusion_GpuOnly(benchmark::State& benchmark_state) {
+//   Fusion fusion;
+
+//   // setup fusion
+//   setupFusion(&fusion);
+
+//   // inputs
+//   std::vector<c10::IValue> inputs = setupInputs();
+
+//   // outputs
+//   std::vector<at::Tensor> outputs;
+
+//   auto lparams = schedulePointwise(&fusion, c10::ArrayRef<c10::IValue>(inputs));
+
+//   FusionExecutor executor;
+//   executor.setMeasureKernelTimeFlag(true);
+//   executor.compileFusion(&fusion);
+
+//   C10_CUDA_CHECK(cudaDeviceSynchronize());
+
+//   for (auto _ : benchmark_state) {
+//     outputs = executor.runFusion(c10::ArrayRef<c10::IValue>(inputs), lparams);
+//     benchmark_state.SetIterationTime(executor.kernelTimeMs() / 1000.0);
+//     clearL2Cache();
+//   }
+// }
+
+// BENCHMARK(IndexSelect_RunFusion_GpuOnly)
+//     ->Unit(benchmark::kMicrosecond)
+//     ->UseManualTime();
+
+// //------------------------------------------------------------------------------
+
+// static void IndexSelect_RunFusion_CpuOnly(benchmark::State& benchmark_state) {
+//   Fusion fusion;
+
+//   // setup fusion
+//   setupFusion(&fusion);
+
+//   // inputs
+//   std::vector<c10::IValue> inputs = setupInputs();
+
+//   // outputs
+//   std::vector<at::Tensor> outputs;
+
+//   auto lparams = schedulePointwise(&fusion, c10::ArrayRef<c10::IValue>(inputs));
+
+//   FusionExecutor executor;
+//   executor.setExecuteKernelFlag(false);
+//   executor.compileFusion(&fusion);
+
+//   for (auto _ : benchmark_state) {
+//     outputs = executor.runFusion(c10::ArrayRef<c10::IValue>(inputs), lparams);
+//   }
+// }
+
+// BENCHMARK(IndexSelect_RunFusion_CpuOnly)->Unit(benchmark::kMicrosecond);

--- a/benchmarks/cpp/nvfuser/indexselect.cpp
+++ b/benchmarks/cpp/nvfuser/indexselect.cpp
@@ -319,7 +319,7 @@ NVFUSER_BENCHMARK_DEFINE(
     0);
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_IndexSelectSimple_Outer_fp32)
-    ->Ranges({{128, 128}, {512, 512}})
+    ->Ranges({{32768, 32768}, {65536,65536}})
     ->Unit(benchmark::kMicrosecond)
 ->UseManualTime();
 
@@ -425,7 +425,7 @@ static void Baseline_IndexSelectFused_Outer_fp32(benchmark::State& benchmark_sta
 
 BENCHMARK(Baseline_IndexSelectSimple_Outer_fp32)
     // ->RangeMultiplier(2)
-    ->Ranges({{128,128}, {512, 512}})
+    ->Ranges({{32768, 32768}, {65536,65536}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 


### PR DESCRIPTION
## Background

We are adding some sparse operators, like `index_select`/`gather`/`scatter` and some related sparseMM, to nvfuser to better support GNN applications. Apart from unit and e2e tests, adding benchmarks for any new, tentative graph-related operators helps improve the quality, track/compare the performance with the torch baseline impl. , and spot the possible overheads/regressions earlier. This PR adds such benchmark for `index_select` operator, and also can serve as a template to benchmark future graph-related ops.

## Benchmarks

### Benchmarking the setup/schedule/lower/compile overheads
- cmd line:
  `./build/bin/nvfuser_bench  --benchmark_filter=IndexSelect_`
- Sample output:
```
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
IndexSelect_SetupFusion        20.9 us         20.9 us         6705
IndexSelect_AutoSchedule       7477 us         7474 us           18
IndexSelect_Lower              14.0 ms         14.0 ms            9
IndexSelect_Compile             153 ms          153 ms            1
IndexSelect_RunFusion          33.4 us         33.4 us         4170
```
### Benchmarking a single `index_select` operator (not fused with other operations) together with torch `at::index_select`
- cmd line:
`./build/bin/nvfuser_bench  --benchmark_filter=IndexSelectSimple`
- Sample output:
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
NvFuserScheduler_IndexSelectSimple_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectSimple_Outer_fp32/32768/65536/manual_time       99.6 us          154 us         1398 bytes_per_second=316.057G/s 2D Schedule at 1/ Split block into y-dim/Vectorize, Factor: 2/Launch_Parameters[block(1/2/64)/grid(1/32768/1)/0]
Baseline_IndexSelectSimple_Outer_fp32/32768/65536/manual_time                                                                      135 us          178 us         1035 bytes_per_second=233.582G/s

```
### Benchmarking `index_select`  fused with elem-wise operators by varying the extent of input and select axis
- cmd line:
`./build/bin/nvfuser_bench  --benchmark_filter=IndexSelectFused`
- Sample output:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                                          Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/128/16/manual_time            3.84 us         36.3 us        35497 bytes_per_second=5.96971G/s 1D//Launch_Parameters[block(1/1/128)/grid(1/1/16)/0]
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/512/16/manual_time            3.82 us         36.4 us        36607 bytes_per_second=6.00123G/s 1D//Launch_Parameters[block(1/1/128)/grid(1/1/16)/0]
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/4096/16/manual_time           3.85 us         35.8 us        36403 bytes_per_second=5.96461G/s 1D//Launch_Parameters[block(1/1/128)/grid(1/1/16)/0]
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/32768/16/manual_time          3.83 us         36.3 us        36765 bytes_per_second=5.99809G/s 1D//Launch_Parameters[block(1/1/128)/grid(1/1/16)/0]
...
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/128/32768/manual_time         53.3 us         85.6 us         2629 bytes_per_second=882.254G/s 2D Schedule at 1/ Split block into y-dim/Vectorize, Factor: 2/Launch_Parameters[block(1/2/64)/grid(1/16384/1)/0]
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/512/32768/manual_time         53.4 us         85.7 us         2621 bytes_per_second=879.847G/s 2D Schedule at 1/ Split block into y-dim/Vectorize, Factor: 2/Launch_Parameters[block(1/2/64)/grid(1/16384/1)/0]
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/4096/32768/manual_time        60.3 us         92.6 us         2321 bytes_per_second=778.851G/s 2D Schedule at 1/ Split block into y-dim/Vectorize, Factor: 2/Launch_Parameters[block(1/2/64)/grid(1/16384/1)/0]
NvFuserScheduler_IndexSelectFused_Outer_fp32___GRAPH/NvFuserScheduler_IndexSelectFused_Outer_fp32/32768/32768/manual_time       75.4 us          108 us         1857 bytes_per_second=623.26G/s 2D Schedule at 1/ Split block into y-dim/Vectorize, Factor: 2/Launch_Parameters[block(1/2/64)/grid(1/16384/1)/0]
Baseline_IndexSelectFused_Outer_fp32/128/16/manual_time                                                                         18.7 us         54.1 us         7477 bytes_per_second=1.22466G/s
Baseline_IndexSelectFused_Outer_fp32/512/16/manual_time                                                                         18.7 us         54.0 us         7475 bytes_per_second=1.22607G/s
Baseline_IndexSelectFused_Outer_fp32/4096/16/manual_time                                                                        18.6 us         53.9 us         7473 bytes_per_second=1.23084G/s
Baseline_IndexSelectFused_Outer_fp32/32768/16/manual_time                                                                       18.9 us         54.1 us         7418 bytes_per_second=1.21592G/s
...
Baseline_IndexSelectFused_Outer_fp32/128/32768/manual_time                                                                       186 us          222 us          753 bytes_per_second=252.216G/s
Baseline_IndexSelectFused_Outer_fp32/512/32768/manual_time                                                                       186 us          222 us          752 bytes_per_second=252.024G/s
Baseline_IndexSelectFused_Outer_fp32/4096/32768/manual_time                                                                      188 us          224 us          745 bytes_per_second=249.875G/s
Baseline_IndexSelectFused_Outer_fp32/32768/32768/manual_time                                                                     196 us          232 us          715 bytes_per_second=240.223G/s
```

 